### PR TITLE
Prevent mutation of global state initializer

### DIFF
--- a/src/component/trade/index.ts
+++ b/src/component/trade/index.ts
@@ -42,9 +42,9 @@ export class TradeApp extends LitElement {
   });
   private disconnectSubscribeNewHeads: () => void = null;
 
-  @state() screen: ScreenState = DEFAULT_SCREEN_STATE;
-  @state() assets: AssetsState = DEFAULT_ASSETS_STATE;
-  @state() trade: TradeState = DEFAULT_TRADE_STATE;
+  @state() screen: ScreenState = { ...DEFAULT_SCREEN_STATE };
+  @state() assets: AssetsState = { ...DEFAULT_ASSETS_STATE };
+  @state() trade: TradeState = { ...DEFAULT_TRADE_STATE };
 
   @property({ type: String }) apiAddress: string = null;
   @property({ type: String }) accountAddress: string = null;


### PR DESCRIPTION
As the property is shallowly set, modifying the trade state will also modify the initializing object. 

This PR aims to clone the object 1 level deep in order to prevent mutating initializer by mistake.