### PR TITLE
Suggest fee asset change on failed txn message

### DIFF
--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -23,7 +23,7 @@
   "trade.error.invalidPair": "Selected pool pair is not valid",
   "notify.recent": "Recent activities",
   "tx.failed": "Failed to submit transaction",
-  "tx.failedText": "Unfortunately there was an issue while submitting your transaction. Please try again later.",
+  "tx.failedText": "Unfortunately there was an issue while submitting your transaction. Please change your fee payment asset or try again later.",
   "tx.submittedText": "Your transaction has been submitted successfully.",
   "tx.submitted": "Submitted",
   "tx.close": "Close",


### PR DESCRIPTION
The most common reason for the failed transaction message has been not enough fee payment asset. Suggesting the user try changing it may help some users figure out what is wrong.