### PR TITLE
Added offset to stop color in Warning icon - Safari fix

### DIFF
--- a/packages/ui/src/component/icons/Warning.ts
+++ b/packages/ui/src/component/icons/Warning.ts
@@ -46,7 +46,7 @@ export class WarningIcon extends BaseIcon {
             gradientUnits="userSpaceOnUse">
             <stop
               style="offset: var(--stop-first-offset); stop-color: var(--stop-first-color); " />
-            <stop style="stop-color: var(--stop-second-color); " />
+            <stop offset="1" style="stop-color: var(--stop-second-color); " />
           </linearGradient>
         </defs>
       </svg>


### PR DESCRIPTION
![image](https://github.com/galacticcouncil/apps/assets/3890412/849c4622-1475-4388-999a-52c4e0b35968)
