### PR TITLE
Fixed getPaymentFeeAsset address format

### DIFF
--- a/packages/apps/src/app/xcm/App.ts
+++ b/packages/apps/src/app/xcm/App.ts
@@ -1001,7 +1001,9 @@ export class XcmApp extends PoolApp {
     let srcChainFee: AssetAmount;
     let srcChainMax: AssetAmount;
     if (srcChain.key == 'hydradx') {
-      const feeAssetId = await this.paymentApi.getPaymentFeeAsset(address);
+      const feeAssetId = await this.paymentApi.getPaymentFeeAsset(
+        addr.isH160(address) ? convertFromH160(address) : address,
+      );
       const feeAsset = this.assets.registry.get(feeAssetId);
       srcChainFee = await this.calculateSourceFee(
         xTransfer,


### PR DESCRIPTION
When checking fee payment asset, address can be in H160 format, so we convert it.
Otherwise it will fail to determine fee payment asset and falls back to HDX.