### PR TITLE
Replace trade routes asset symbols with icons

### DIFF
--- a/.changeset/famous-pans-sit.md
+++ b/.changeset/famous-pans-sit.md
@@ -1,0 +1,5 @@
+---
+'@galacticcouncil/apps': minor
+---
+
+shorten long swap routes

--- a/packages/apps/src/app/trade/App.css
+++ b/packages/apps/src/app/trade/App.css
@@ -25,3 +25,7 @@
     stroke: #ecedef;
   }
 }
+
+uigc-paper.main.form-tab {
+  overflow: inherit;
+}

--- a/packages/apps/src/app/trade/App.ts
+++ b/packages/apps/src/app/trade/App.ts
@@ -981,6 +981,7 @@ export class TradeApp extends PoolApp {
       tab: true,
       main: true,
       active: this.tab == TradeTab.Form,
+      'form-tab': this.tab == TradeTab.Form,
     };
     return html`
       <uigc-paper class=${classMap(classes)} id="default-tab">

--- a/packages/apps/src/app/trade/Form.css
+++ b/packages/apps/src/app/trade/Form.css
@@ -217,6 +217,39 @@
   color: var(--uigc-field__error-color);
 }
 
+.tooltip-text {
+  padding: 11px 16px;
+  border-radius: 4px;
+  background: #333750;
+  color: #fff;
+  font-family: 'Geist';
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 140%;
+  text-align: left;
+}
+
+.middle-route-tooltip {
+  position: relative;
+  white-space: nowrap;
+}
+
+.middle-route-tooltip > .text {
+  visibility: hidden;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  top: 25px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.middle-route-tooltip:hover > .text {
+  visibility: visible;
+}
+
 .tooltip {
   position: relative;
   width: 22px;
@@ -327,4 +360,8 @@
 .swap-bottom-spacer {
   height: 22px;
   width: 100%;
+}
+
+.middle-route {
+  color: var(--hex-bright-blue-200);
 }

--- a/packages/apps/src/app/trade/Form.ts
+++ b/packages/apps/src/app/trade/Form.ts
@@ -465,6 +465,34 @@ export class TradeForm extends BaseElement {
 
   bestRouteTemplate() {
     const bestRoute = this.getBestRoute();
+    const lastRoute = bestRoute[bestRoute.length - 1];
+    const middleRoute = bestRoute.slice(0, -1);
+
+    if (middleRoute.length > 1) {
+      return html`
+        <span class="value">${this.assetIn.symbol}</span>
+        <uigc-icon-chevron-right></uigc-icon-chevron-right>
+        <span class="middle-route-tooltip">
+          <span class="middle-route">Hydration Router</span>
+          <span class="text tooltip-text">
+            ${middleRoute.map(
+              (route, index) => html`
+                ${when(
+                  index > 0,
+                  () => html`
+                    <uigc-icon-chevron-right></uigc-icon-chevron-right>
+                  `,
+                )}
+                <span>${route}</span>
+              `,
+            )}
+          </span>
+        </span>
+        <uigc-icon-chevron-right></uigc-icon-chevron-right>
+        <span class="value">${lastRoute}</span>
+      `;
+    }
+
     return html`
       <span class="value">${this.assetIn.symbol}</span>
       ${bestRoute.map(
@@ -474,7 +502,6 @@ export class TradeForm extends BaseElement {
             <span class="value">${poolAsset}</span>
           `,
       )}
-      <uigc-icon-route></uigc-icon-route>
     `;
   }
 


### PR DESCRIPTION
Current solution with asset symbols is too long for our UI (as we can have currently as much as 9 hops)
Not ideal for mobile nor web.
Asset icons instead of symbols didn't help either.
I think best solution would be to display source and destination asset and inbetween kind of info about selected route.
We can do this for router longer than 4 hops for example.

### Update:
Updated design where we will display just asset in and asset out (so pay with asset and you get asset),between them always "Hydration Router" and on hover/click(on mobile) we will display complete route (can be tuned for mobile designs into multiple rows.

Design: https://www.figma.com/design/eqzR2azTracqA8Vv0y4GUv/%F0%9F%96%A5--Hydra-%7C-Desktop-Library?node-id=6623-101277&t=ioUMVf2ZaZHoTJPa-4